### PR TITLE
feat: Implement resizable panels and file explorer toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "react-resizable-panels": "^3.0.2",
         "react-syntax-highlighter": "^15.6.1",
         "react-toastify": "^11.0.5",
         "remark-gfm": "^4.0.1",
@@ -5873,6 +5874,15 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-resizable-panels": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.2.tgz",
+      "integrity": "sha512-j4RNII75fnHkLnbsTb5G5YsDvJsSEZrJK2XSF2z0Tc2jIonYlIVir/Yh/5LvcUFCfs1HqrMAoiBFmIrRjC4XnA==",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-syntax-highlighter": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz",
@@ -11444,6 +11454,12 @@
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
       }
+    },
+    "react-resizable-panels": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.2.tgz",
+      "integrity": "sha512-j4RNII75fnHkLnbsTb5G5YsDvJsSEZrJK2XSF2z0Tc2jIonYlIVir/Yh/5LvcUFCfs1HqrMAoiBFmIrRjC4XnA==",
+      "requires": {}
     },
     "react-syntax-highlighter": {
       "version": "15.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^3.0.2",
     "react-syntax-highlighter": "^15.6.1",
     "react-toastify": "^11.0.5",
     "remark-gfm": "^4.0.1",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -109,3 +109,53 @@
 .prose em {
   @apply text-gray-200;
 }
+
+/* Styles for react-resizable-panels Handle */
+.resize-handle-outer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  border: none; /* Or a subtle border */
+  background-color: transparent; /* Or a very subtle color */
+  /* transition for background color if needed */
+  /* transition: background-color 0.2s ease-in-out; */
+}
+
+.resize-handle-outer[data-orientation="horizontal"] {
+  width: 12px; /* Increased width for easier grabbing */
+  cursor: ew-resize;
+}
+
+.resize-handle-outer[data-orientation="vertical"] {
+  height: 12px; /* Increased height for easier grabbing */
+  cursor: ns-resize;
+}
+
+.resize-handle-inner {
+  width: 2px; /* Width of the visible line */
+  height: 24px; /* Height of the visible line for horizontal handles */
+  background-color: #374151; /* gray-700, adjust as needed */
+  border-radius: 1px;
+  /* transition for background color for hover effect */
+  transition: background-color 0.2s ease-in-out;
+}
+
+.resize-handle-outer[data-orientation="vertical"] .resize-handle-inner {
+  width: 24px; /* Width of the visible line for vertical handles */
+  height: 2px; /* Height of the visible line */
+}
+
+.resize-handle-outer:hover .resize-handle-inner {
+  background-color: #4b5563; /* gray-600, adjust hover color */
+}
+
+/* Remove default panel resize handle styling if it was applied through tailwind previously */
+/* For example, if you had something like this in page.js: className="w-1 bg-gray-800 hover:bg-gray-700 transition-colors" */
+/* You might not need this if the new classes completely override or if the old classes were removed */
+.w-1.bg-gray-800.hover\\:bg-gray-700.transition-colors {
+  background-color: transparent !important; /* Overriding previous inline/tailwind styles */
+}
+.w-1.bg-gray-800.hover\\:bg-gray-700.transition-colors:hover .resize-handle-inner {
+   /* Ensure hover on outer still colors inner if needed, or manage hover on .resize-handle-outer directly */
+}

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -5,8 +5,9 @@ import { FileExplorer } from "@/components/file-explorer"
 import FileEditor from "@/components/file-editor"
 import { MarkdownPreview } from "@/components/markdown-preview"
 import { Button } from "@/components/ui/button"
-import { FolderOpen } from "lucide-react"
+import { FolderOpen, PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { ToastContainer, toast, Bounce } from 'react-toastify'
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels"
 
 const encodePath = (path) =>
   path
@@ -18,6 +19,7 @@ export default function Home() {
   const [files, setFiles] = useState([])
   const [currentFileName, setCurrentFileName] = useState("")
   const [content, setContent] = useState("")
+  const [isFileExplorerVisible, setIsFileExplorerVisible] = useState(true)
 
   const loadFiles = async () => {
     try {
@@ -99,7 +101,21 @@ export default function Home() {
     <div className="h-screen bg-gray-950 text-gray-100 flex flex-col">
       <ToastContainer />
       <div className="border-b border-gray-800 p-4 flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Assist</h1>
+        <div className="flex items-center gap-4">
+          <Button
+            onClick={() => setIsFileExplorerVisible(!isFileExplorerVisible)}
+            variant="outline"
+            size="icon"
+            className="bg-gray-900 border-gray-700 hover:bg-gray-800"
+          >
+            {isFileExplorerVisible ? (
+              <PanelLeftClose className="w-5 h-5" />
+            ) : (
+              <PanelLeftOpen className="w-5 h-5" />
+            )}
+          </Button>
+          <h1 className="text-xl font-semibold">Assist</h1>
+        </div>
         <Button onClick={loadFiles} variant="outline" className="bg-gray-900 border-gray-700 hover:bg-gray-800">
           <FolderOpen className="w-4 h-4 mr-2" />
           Reload Files
@@ -107,23 +123,42 @@ export default function Home() {
       </div>
 
       <div className="flex-1 flex overflow-hidden">
-        <div className="w-80 border-r border-gray-800 bg-gray-950">
-          <FileExplorer files={files} onFileSelect={openFile} />
-        </div>
-
-        <div className="flex-1 flex">
-          <div className="flex-1 border-r border-gray-800">
-            <FileEditor
-              content={content}
-              onChange={setContent}
-              fileName={currentFileName || "Untitled"}
-              onRename={handleRename}
-            />
-          </div>
-          <div className="flex-1">
-            <MarkdownPreview content={content} />
-          </div>
-        </div>
+        <PanelGroup direction="horizontal" className="flex-1">
+          {isFileExplorerVisible && (
+            <Panel defaultSize={20} minSize={10} collapsible={true} collapsed={!isFileExplorerVisible} onCollapse={setIsFileExplorerVisible}>
+              <div className="h-full border-r border-gray-800 bg-gray-950 overflow-y-auto">
+                <FileExplorer files={files} onFileSelect={openFile} />
+              </div>
+            </Panel>
+          )}
+          {isFileExplorerVisible && (
+            <PanelResizeHandle className="resize-handle-outer">
+              <div className="resize-handle-inner" />
+            </PanelResizeHandle>
+          )}
+          <Panel>
+            <PanelGroup direction="horizontal" className="flex-1">
+              <Panel defaultSize={isFileExplorerVisible ? 50 : 100} minSize={20}>
+                <div className="h-full border-r border-gray-800">
+                  <FileEditor
+                    content={content}
+                    onChange={setContent}
+                    fileName={currentFileName || "Untitled"}
+                    onRename={handleRename}
+                  />
+                </div>
+              </Panel>
+              <PanelResizeHandle className="resize-handle-outer">
+                <div className="resize-handle-inner" />
+              </PanelResizeHandle>
+              <Panel defaultSize={50} minSize={20}>
+                <div className="h-full">
+                  <MarkdownPreview content={content} />
+                </div>
+              </Panel>
+            </PanelGroup>
+          </Panel>
+        </PanelGroup>
       </div>
     </div>
   )


### PR DESCRIPTION
This commit introduces resizable panels for the file explorer, editor, and markdown preview, and adds a toggle button for the file explorer.

Key changes:
- Added `react-resizable-panels` library to manage panel resizing.
- Modified `frontend/src/app/page.js`:
    - Wrapped FileExplorer, FileEditor, and MarkdownPreview in resizable panels.
    - Implemented a toggle button for the FileExplorer using `PanelLeftClose` and `PanelLeftOpen` icons.
    - The FileExplorer panel can be collapsed and expanded.
- Added styling for the resize handles in `frontend/src/app/globals.css` to make them visible and interactive.

These changes allow you to customize your workspace layout by adjusting the width of different sections and by showing or hiding the file explorer.