### PR TITLE
Fix: Address multiple frontend issues and API route errors

### DIFF
--- a/frontend/src/app/api/files/[...filename]/route.js
+++ b/frontend/src/app/api/files/[...filename]/route.js
@@ -13,7 +13,8 @@ function safeJoin(...segments) {
 }
 
 export async function GET(req, { params }) {
-  const filename = params.filename.join('/')
+  const awaitedParams = await params;
+  const filename = awaitedParams.filename.join('/')
   const full = safeJoin(BASE_PATH, filename)
 
   try {
@@ -31,7 +32,8 @@ export async function GET(req, { params }) {
 }
 
 export async function PATCH(req, { params }) {
-  const filename = params.filename.join('/')
+  const awaitedParams = await params;
+  const filename = awaitedParams.filename.join('/')
   const full = safeJoin(BASE_PATH, filename)
   const { newName } = await req.json()
 
@@ -65,7 +67,8 @@ export async function PATCH(req, { params }) {
 }
 
 export async function POST(req, { params }) {
-  const filename = params.filename.join('/')
+  const awaitedParams = await params;
+  const filename = awaitedParams.filename.join('/')
   const full = safeJoin(BASE_PATH, filename)
   const body = await req.json()
 
@@ -79,6 +82,21 @@ export async function POST(req, { params }) {
   try {
     await fs.mkdir(path.dirname(full), { recursive: true })
     await fs.writeFile(full, body.content, 'utf-8')
+    return NextResponse.json({ message: 'File saved' })
+  } catch (e) {
+    return NextResponse.json({ detail: e.message || String(e) }, { status: 500 })
+  }
+}
+
+export async function PUT(req, { params }) {
+  const awaitedParams = await params;
+  const filename = awaitedParams.filename.join('/')
+  const full = safeJoin(BASE_PATH, filename)
+
+  try {
+    const bodyAsText = await req.text();
+    await fs.mkdir(path.dirname(full), { recursive: true })
+    await fs.writeFile(full, bodyAsText, 'utf-8')
     return NextResponse.json({ message: 'File saved' })
   } catch (e) {
     return NextResponse.json({ detail: e.message || String(e) }, { status: 500 })

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -113,7 +113,7 @@ export default function Home() {
         <PanelGroup direction="horizontal" className="flex-1">
           {isFileExplorerVisible && (
             // Temporarily removing onCollapse to test if it's the source of the warning
-            <Panel defaultSize={20} minSize={10} collapsible={true} collapsed={!isFileExplorerVisible} /* onCollapse={() => setIsFileExplorerVisible(false)} */ >
+            <Panel defaultSize={20} minSize={10} collapsible={true} collapsed={!isFileExplorerVisible ? true : undefined} /* onCollapse={() => setIsFileExplorerVisible(false)} */ >
               <div className="h-full border-r border-gray-800 bg-gray-950 overflow-y-auto">
                 <FileExplorer
                   files={files}
@@ -129,7 +129,7 @@ export default function Home() {
               <div className="resize-handle-inner" />
             </PanelResizeHandle>
           )}
-          <Panel>
+          <Panel defaultSize={isFileExplorerVisible ? 80 : 100}>
             <PanelGroup direction="horizontal" className="flex-1">
               <Panel defaultSize={isFileExplorerVisible ? 50 : 100} minSize={20}>
                 <div className="h-full border-r border-gray-800">


### PR DESCRIPTION
This commit resolves several issues observed in the frontend application:

1.  **API Route `params` Usage:** Modified the API route handlers (`GET`, `PATCH`, `POST`) in `frontend/src/app/api/files/[...filename]/route.js` to correctly `await params` before accessing `params.filename`. This addresses the "Route ... used `params.filename`. `params` should be awaited" error from Next.js.

2.  **Boolean Attribute Warning for `collapsed`:** In `frontend/src/app/page.js`, the `collapsed` prop for the `react-resizable-panels` Panel component was changed from `!isFileExplorerVisible` to `!isFileExplorerVisible ? true : undefined`. This prevents a boolean `false` from being passed, resolving the React warning about non-boolean attributes in the DOM.

3.  **Panel `defaultSize` Warning:** Added the `defaultSize` prop to a `Panel` component in `frontend/src/app/page.js` that was missing it. The value is set dynamically based on the visibility of the file explorer (`defaultSize={isFileExplorerVisible ? 80 : 100}`), which should prevent layout shifts and satisfy the recommendation.

4.  **405 Error for PUT Requests (File Saving):** The frontend sends a `PUT` request with `text/plain` content when saving files. The backend API route `frontend/src/app/api/files/[...filename]/route.js` lacked a `PUT` handler.
    - A `PUT` handler has been added to this route.
    - This handler reads the request body as text (`req.text()`) and writes it to the specified file, similar to the existing `POST` handler but adapted for `text/plain` content. This resolves the 405 "Method Not Allowed" error and enables file saving functionality.